### PR TITLE
Setting update-notifier version strictly to 0.2.0 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "yeoman-generator": "~0.16.0",
-    "update-notifier": "~0.2.0",
+    "update-notifier": "0.2.0",
     "string-length": "^0.1.2",
     "chalk": "^0.5.1",
     "simple-git": "^0.10.0"


### PR DESCRIPTION
because of incompatibility of package's callback in versions >0.2.0. 
Will be changed after resolving the issue.
