### PR TITLE
Lock grunt-usemin version to 3.0.0

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -25,7 +25,7 @@
     "grunt-jsbeautifier": "^0.2.10",
     "grunt-cssbeautifier": "^0.1.2",
     "grunt-html-validation": "^0.1.18",
-    "grunt-usemin": "^3.0.0",<% if (reloader === 'BrowserSync') { %>
+    "grunt-usemin": "3.0.0",<% if (reloader === 'BrowserSync') { %>
     "grunt-browser-sync": "^2.1.3",<% } else if (reloader === 'LiveReload' && server) { %>
     "grunt-contrib-connect": "^0.10.1",<% } %>
     "grunt-notify": "^0.4.1",


### PR DESCRIPTION
3.1.0 breaks out generator due to the updated file name (uglifyjs -> uglify). The script's authors recommend to stick to 3.0.0 until they find a solution for this breaking change.

I suggest to observe Usemin's doings (whether they decided to keep this file name or support both?) and update our generator accordingly.