### PR TITLE
Upgrade spritesmith grunt task, to keep compatibility with current version

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -31,7 +31,8 @@
     "grunt-notify": "^0.4.1",
     "grunt-contrib-imagemin": "^0.9.4",
     "grunt-newer": "^1.1.1",<% if (features.useSprites) { %>
-    "grunt-spritesmith": "^4.7.1",<% } %>
+    "grunt-spritesmith": "^4.7.1",
+    "pngsmith": "^0.1.3",<% } %>
     "grunt-svg2png": "^0.2.7",
     "time-grunt": "^1.2.1",
     "jit-grunt": "0.9.1",

--- a/app/templates/grunt/spritesmith.js
+++ b/app/templates/grunt/spritesmith.js
@@ -7,8 +7,8 @@ module.exports = function(grunt) {
   grunt.config('sprite', {
     dist1x: {
       src: '<%%= xh.src %>/img/sprites/1x/*.{png,jpg,gif}',
-      destImg: '<%%= xh.dist %>/img/common/sprites@1x.png',
-      destCSS: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites@1x.scss'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites@1x.less'<% } %>,
+      dest: '<%%= xh.dist %>/img/common/sprites@1x.png',
+      destCss: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites@1x.scss'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites@1x.less'<% } %>,
       cssTemplate: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites.scss.mustache'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites.less.mustache'<% } %>,
       algorithm: 'binary-tree',
       engine: 'pngsmith',
@@ -19,8 +19,8 @@ module.exports = function(grunt) {
     },
     dist2x: {
       src: '<%%= xh.src %>/img/sprites/2x/*.{png,jpg,gif}',
-      destImg: '<%%= xh.dist %>/img/common/sprites@2x.png',
-      destCSS: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites@2x.scss'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites@2x.less'<% } %>,
+      dest: '<%%= xh.dist %>/img/common/sprites@2x.png',
+      destCss: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites@2x.scss'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites@2x.less'<% } %>,
       cssTemplate: <% if (cssPreprocessor === 'SCSS' || cssPreprocessor === 'LIBSASS') { %>'<%%= xh.src %>/scss/setup/_sprites.scss.mustache'<% } %><% if (cssPreprocessor === 'LESS') { %>'<%%= xh.src %>/less/setup/sprites.less.mustache'<% } %>,
       algorithm: 'binary-tree',
       engine: 'pngsmith',


### PR DESCRIPTION
Recent version of grunt-spritesmith introduced change of variable naming in configuration, which breaks backwards compatibility. See hudochenkov/grunt-spritesmith-retina-mixins#1

Please review these changes and provide feedback.