### PR TITLE
Fix variable context issue in sprite mustache template

### DIFF
--- a/app/templates/src/scss/setup/_sprites.scss.mustache
+++ b/app/templates/src/scss/setup/_sprites.scss.mustache
@@ -5,7 +5,7 @@
 }
 
 {{#items}}
-${{options.map}}-{{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.height}} {{px.total_width}} {{px.total_height}} '{{{escaped_image}}}';
+${{../options.map}}-{{name}}: {{px.x}} {{px.y}} {{px.offset_x}} {{px.offset_y}} {{px.width}} {{px.height}} {{px.total_width}} {{px.total_height}} '{{{escaped_image}}}';
 {{/items}}
 
 {{#options.functions}}


### PR DESCRIPTION
Fixes problem with no prefix being prepended to SCSS variable names in sprite setup stylesheet (so we can finally use retina sprites).

File output before:
```
$-myimagename: 0px 35px...
```
After:
```
$sprite-1x-myimagename: 0px 35px...
```

Happy spriting! 🙌