### PR TITLE
Fix problem with "dist" folder

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -33,7 +33,7 @@ nbproject
 .tmp
 node_modules
 bower_components<% if (ignoreDist) { %>
-dist<% if (isWP) { %>
+/dist<% if (isWP) { %>
 wp/wp-content/themes/**/img
 wp/wp-content/themes/**/fonts
 wp/wp-content/themes/**/js

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -33,13 +33,13 @@ nbproject
 .tmp
 node_modules
 bower_components<% if (ignoreDist) { %>
-/dist<% if (isWP) { %>
+/dist<% } %><% if (isWP) { %>
 wp/wp-content/themes/**/img
 wp/wp-content/themes/**/fonts
 wp/wp-content/themes/**/js
 wp/wp-content/themes/**/css
 wp/wp-content/themes/**/media
-wp/wp-content/uploads<% } %><% } %>
+wp/wp-content/uploads<% } %>
 
 # Other
 validation-report.json


### PR DESCRIPTION
Making "dist" folder ignored causes problems with some plugins in Wordpress (i.e. Yoast SEO), which uses folders named "dist" to store assets. Changing from "dist" to "/dist" should solve the problem.

Both changes fix also missing wordpress folders in gitignore when "dist" is not added to gitignore during setup 

See issue: #205
